### PR TITLE
Improved Win32 support

### DIFF
--- a/engine/PisteDraw.cpp
+++ b/engine/PisteDraw.cpp
@@ -13,8 +13,10 @@
 
 #include <SDL2/SDL_image.h>
 
+#include "platform.h"
+
 #ifdef _WIN32
-#include "win32hacks.h"
+#include "win32_clock.h"
 #endif
 
 const int MAX_IMAGES = 2000;
@@ -182,7 +184,7 @@ int PisteDraw2_Image_CutClip(int index, PD_RECT srcrect, PD_RECT dstrect){
 	return 0;
 }
 int PisteDraw2_Image_CutClipTransparent(int index, PD_RECT srcrect, PD_RECT dstrect, int alpha){
-	PisteDraw2_Image_CutClipTransparent(index, srcrect, dstrect, alpha, 0);
+	return PisteDraw2_Image_CutClipTransparent(index, srcrect, dstrect, alpha, 0);
 }
 int PisteDraw2_Image_CutClipTransparent(int index, PD_RECT srcrect, PD_RECT dstrect, int alpha, int colorsum){
 	BYTE *imagePix = NULL;
@@ -287,6 +289,7 @@ int PisteDraw2_DrawImage_Start(int index, BYTE* &pixels, DWORD &pitch){
 }
 int PisteDraw2_DrawImage_End(int index){
 	SDL_UnlockSurface(imageList[index]);
+	return 0;
 }
 BYTE PisteDraw2_BlendColors(BYTE color, BYTE colBack, int alpha){
 	int result;

--- a/engine/PisteEngine.cpp
+++ b/engine/PisteEngine.cpp
@@ -5,6 +5,9 @@
 
 #include <SDL2/SDL.h>
 #include <string>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 #include "PisteEngine.h"
 
 using namespace std;
@@ -12,6 +15,7 @@ using namespace std;
 #ifdef _WIN32
 	#include "stdio.h"
 	#include "stdlib.h"
+	#include "winlite.h"
 #else
 	#define _MAX_PATH PATH_MAX
 	#include <unistd.h>
@@ -57,7 +61,7 @@ int Setcwd(){
 	char exepath[_MAX_PATH];
 	int count, find;
 
-	#ifdef WINDOWS
+	#ifdef _WIN32
 		string(exepath, GetModuleFileName(NULL, exepath, _MAX_PATH));
 	#else
 		count = readlink("/proc/self/exe", exepath, _MAX_PATH);

--- a/engine/PisteEngine.h
+++ b/engine/PisteEngine.h
@@ -6,9 +6,7 @@
 #ifndef P_ENGINE
 #define P_ENGINE
 
-#ifdef _WIN32
-#include "win32hacks.h"
-#endif
+#include "platform.h"
 
 #include "types.h"
 

--- a/engine/PisteFont.cpp
+++ b/engine/PisteFont.cpp
@@ -12,9 +12,7 @@
 #include <iostream>
 #include <string.h>
 
-#ifdef _WIN32
-#include "win32hacks.h"
-#endif
+#include "platform.h"
 
 int PisteFont2::InitCharList(){
 	int font_index[256], i;
@@ -200,9 +198,17 @@ int PisteFont2::Write_TextTrasparent(int posx, int posy, const char* text, int a
 						fy *= back_w;
 						fy += fx;
 
+#ifdef _WIN32 // TODO: Windows: Update project to MSVC15 to make binary literals work?
+						color1 &= (unsigned int)0x1F;
+#else
 						color1 &= 0b00011111;
+#endif
 						color2 = back_buffer[fy];
+#ifdef _WIN32
+						color3 = color2 & (unsigned int)0xE0;
+#else
 						color3 = color2 & 0b11100000;
+#endif
 						color2-= color3;
 						color1 = (color1 * a1 + color2 * a2)/100;
 						back_buffer[fy] = color1 + color3;

--- a/engine/PisteUtils.cpp
+++ b/engine/PisteUtils.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "PisteUtils.h"
+#include "platform.h"
 
 void PisteUtils_Lower(char* string){
 	int i;

--- a/engine/platform.h
+++ b/engine/platform.h
@@ -1,10 +1,9 @@
-// Win32 redefinitions and stuff to make MSVC happy
-// Pretty lazy huh? :) Need to do this in a better way
+// Platform defs
+#ifndef PLATFORM_H
+#define PLATFORM_H
 
-// this silences error C4996 (eg. 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead.)
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
+// Win32 redefinitions and stuff to make MSVC happy
+#if defined (_WIN32) && defined (_MSC_VER)
 
 // silence macro definition warnings (C4005)
 #pragma warning(disable: 4005)
@@ -22,6 +21,8 @@
 #define strdup _strdup
 #endif
 
+
+// require #include <direct.h>
 #ifndef getcwd
 #define getcwd _getcwd
 #endif
@@ -33,3 +34,12 @@
 #ifndef chdir
 #define chdir _chdir
 #endif
+
+#endif // _WIN32 && _MSC_VER
+
+
+#ifndef _MAX_PATH
+#define _MAX_PATH 128
+#endif
+
+#endif // PLATFORM_H

--- a/engine/types.h
+++ b/engine/types.h
@@ -9,6 +9,10 @@
 #include <stdint.h>
 typedef uint8_t  BYTE;
 typedef uint16_t WORD;
+#ifdef _WIN32
+typedef unsigned long DWORD;
+#else
 typedef uint32_t DWORD;
+#endif
 
 #endif

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -13,7 +13,7 @@
 #include "PisteDraw.h"
 #include "PisteSound.h"
 
-#define _MAX_PATH 128
+#include "platform.h"
 
 using namespace std;
 

--- a/win32/include/win32_clock.h
+++ b/win32/include/win32_clock.h
@@ -1,0 +1,87 @@
+#ifndef WIN32_CLOCK_H
+#define WIN32_CLOCK_H
+
+#include "winlite.h"
+
+struct timespec
+{
+	time_t tv_sec;
+	long tv_nsec;
+};
+
+#define CLOCK_REALTIME                  0
+#define CLOCK_MONOTONIC                 1
+#define CLOCK_PROCESS_CPUTIME_ID        2
+#define CLOCK_THREAD_CPUTIME_ID         3
+#define CLOCK_MONOTONIC_RAW             4
+#define CLOCK_REALTIME_COARSE           5
+#define CLOCK_MONOTONIC_COARSE          6
+#define CLOCK_BOOTTIME                  7
+#define CLOCK_REALTIME_ALARM            8
+#define CLOCK_BOOTTIME_ALARM            9
+
+// https://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows
+LARGE_INTEGER getFILETIMEoffset()
+{
+	SYSTEMTIME s;
+	FILETIME f;
+	LARGE_INTEGER t;
+
+	s.wYear = 1970;
+	s.wMonth = 1;
+	s.wDay = 1;
+	s.wHour = 0;
+	s.wMinute = 0;
+	s.wSecond = 0;
+	s.wMilliseconds = 0;
+	SystemTimeToFileTime( &s, &f );
+	t.QuadPart = f.dwHighDateTime;
+	t.QuadPart <<= 32;
+	t.QuadPart |= f.dwLowDateTime;
+	return ( t );
+}
+
+int clock_gettime( int X, struct timespec *tv )
+{
+	LARGE_INTEGER           t;
+	FILETIME            f;
+	double                  microseconds;
+	static LARGE_INTEGER    offset;
+	static double           frequencyToMicroseconds;
+	static int              initialized = 0;
+	static BOOL             usePerformanceCounter = 0;
+
+	if ( !initialized )
+	{
+		LARGE_INTEGER performanceFrequency;
+		initialized = 1;
+		usePerformanceCounter = QueryPerformanceFrequency( &performanceFrequency );
+		if ( usePerformanceCounter )
+		{
+			QueryPerformanceCounter( &offset );
+			frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
+		}
+		else
+		{
+			offset = getFILETIMEoffset();
+			frequencyToMicroseconds = 10.;
+		}
+	}
+	if ( usePerformanceCounter ) QueryPerformanceCounter( &t );
+	else
+	{
+		GetSystemTimeAsFileTime( &f );
+		t.QuadPart = f.dwHighDateTime;
+		t.QuadPart <<= 32;
+		t.QuadPart |= f.dwLowDateTime;
+	}
+
+	t.QuadPart -= offset.QuadPart;
+	microseconds = (double)t.QuadPart / frequencyToMicroseconds;
+	t.QuadPart = microseconds;
+	tv->tv_sec = t.QuadPart / 1000000;
+	tv->tv_nsec = t.QuadPart % 1000000;
+	return ( 0 );
+}
+
+#endif

--- a/win32/include/winlite.h
+++ b/win32/include/winlite.h
@@ -1,0 +1,17 @@
+#ifndef WINLITE_H
+#define WINLITE_H
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#define NOWINRES
+#define NOSERVICE
+#define NOMCX
+#define NOIME
+
+#include <windows.h>
+
+#endif
+#endif

--- a/win32/pk2.sln
+++ b/win32/pk2.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pk2", "win32\pk2.vcxproj", "{07117172-C1AA-4E87-B798-4787BD53DA1F}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pk2", "pk2.vcxproj", "{07117172-C1AA-4E87-B798-4787BD53DA1F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/win32/pk2.vcxproj
+++ b/win32/pk2.vcxproj
@@ -39,14 +39,15 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)res\</OutDir>
+    <OutDir>..\res\</OutDir>
+    <IntDir>pk2\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)/win32/include;$(SolutionDir)/src;$(SolutionDir)/engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;../src;../engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -86,12 +87,14 @@
     <ClInclude Include="..\engine\PisteFont.h" />
     <ClInclude Include="..\engine\PisteInput.h" />
     <ClInclude Include="..\engine\PisteLanguage.h" />
+    <ClInclude Include="..\engine\platform.h" />
     <ClInclude Include="..\engine\PisteSound.h" />
     <ClInclude Include="..\engine\PisteUtils.h" />
     <ClInclude Include="..\engine\types.h" />
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\sprite.h" />
-    <ClInclude Include="include\win32hacks.h" />
+    <ClInclude Include="include\win32_clock.h" />
+    <ClInclude Include="include\winlite.h" />
   </ItemGroup>
   <ItemGroup>
     <Library Include="lib\x86\SDL2.lib" />

--- a/win32/pk2.vcxproj.filters
+++ b/win32/pk2.vcxproj.filters
@@ -92,7 +92,13 @@
     <ClInclude Include="..\src\sprite.h">
       <Filter>Header Files\Game</Filter>
     </ClInclude>
-    <ClInclude Include="include\win32hacks.h">
+    <ClInclude Include="..\engine\platform.h">
+      <Filter>Header Files\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="include\win32_clock.h">
+      <Filter>Header Files\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="include\winlite.h">
       <Filter>Header Files\Engine</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Hey there, thank you for reminding me that this project exists. :) Pekka Kana 2 was one of my favorite games as a kid and I'm so happy to see it being ported to modern systems. Fantastic work so far!

I see you merged my old Win32 changes which were not that impressive, it was just to make the game compile so I could play it. This commit adds support for your recent changes and it can work as a base for future multi-platform changes.

- Fixed a handful of MSVC compiler errors
- Renamed "win32hacks.h" to "platform.h", which will have defs for
multi-plat compatibility
- Added "winlite.h", which excludes unnecessary WinAPI stuff
- Added "win32_clock.h" to port UNIX clock functions that were used in
code
- Moved solution file to win32 folder