### PR TITLE
github-actions, added msys2 section to makefile

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,39 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android/
+
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+         name: unsigned-release-apk
+         path: android/app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,25 @@
+name: Linux C/C++ CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install SDL dependencies
+      run: sudo apt-get install -y g++ make libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
+    - name: make
+      run: make
+    - uses: actions/upload-artifact@v3
+      with:
+        name: linux-x64-nightly
+        path: |
+          bin/
+          res/

--- a/.github/workflows/c-cpp_woe_64.yml
+++ b/.github/workflows/c-cpp_woe_64.yml
@@ -1,0 +1,47 @@
+name: Windows x64 C/C++ CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
+    - name: Setup MSYS2 and install packages
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          git
+          make
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-SDL2
+          mingw-w64-x86_64-SDL2_mixer
+          mingw-w64-x86_64-SDL2_image
+          mingw-w64-x86_64-libzip
+          mingw-w64-cross-binutils
+
+    - name: make
+      run: make -C mingw/x86_64/
+
+    - name: upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: win64-nightly
+        path: mingw/x86_64/PK2/

--- a/mingw/mingw.mk
+++ b/mingw/mingw.mk
@@ -79,22 +79,46 @@ copyfiles:
 	@mkdir -p $(LICENSES) >/dev/null
 
 	@cp $(BIN_SRC)libogg-0.dll $(BIN_DIR)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.ogg-vorbis.txt))","")
+	@cp /mingw64/share/licenses/libogg/COPYING $(LICENSES)/LICENSE.ogg-vorbis.txt
+  else
 	@cp $(BIN_SRC)LICENSE.ogg-vorbis.txt $(LICENSES)
+  endif
 
 	@cp $(BIN_SRC)libmodplug-1.dll $(BIN_DIR)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.modplug.txt))","")
+	@cp /mingw64/share/licenses/libmodplug/LICENSE $(LICENSES)/LICENSE.modplug.txt
+  else
 	@cp $(BIN_SRC)LICENSE.modplug.txt $(LICENSES)
+  endif
 
 	@cp $(BIN_SRC)libmpg123-0.dll $(BIN_DIR)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.mpg123.txt))","")
+	@cp /mingw64/share/licenses/mpg123/COPYING $(LICENSES)/LICENSE.mpg123.txt
+  else
 	@cp $(BIN_SRC)LICENSE.mpg123.txt $(LICENSES)
+  endif
 
 	@cp $(BIN_SRC)libpng16-16.dll $(BIN_DIR)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.png.txt))","")
+	@cp /mingw64/share/licenses/libpng/LICENSE $(LICENSES)/LICENSE.png.txt
+  else
 	@cp $(BIN_SRC)LICENSE.png.txt $(LICENSES)
+  endif
 
 	@cp $(BIN_SRC)zlib1.dll $(BIN_DIR)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.zlib.tx))","")
+	@cp /mingw64/share/licenses/zlib/LICENSE $(LICENSES)/LICENSE.zlib.txt
+  else
 	@cp $(BIN_SRC)LICENSE.zlib.txt $(LICENSES)
+  endif
 
 	@cp $(BIN_SRC)libzip.dll $(BIN_DIR)
-	@cp $(BIN_SRC)LICENSE.libzip.txt $(LICENSES)
+  ifeq ("$(wildcard $($(BIN_SRC)LICENSE.libzip.txt))","")
+	@cp /mingw64/share/licenses/libzip/LICENSE $(LICENSES)/LICENSE.libzip.txt
+  else
+  @cp $(BIN_SRC)LICENSE.libzip.txt $(LICENSES)
+  endif
 	
 	@cp $(BIN_SRC)SDL2.dll $(BIN_DIR)
 	@cp $(BIN_SRC)SDL2_image.dll $(BIN_DIR)

--- a/mingw/x86_64/Makefile
+++ b/mingw/x86_64/Makefile
@@ -5,9 +5,28 @@ OPT = -O2
 
 CXX = $(PLAT)-w64-mingw32-g++
 WINRES = $(PLAT)-w64-mingw32-windres
-
 BIN_SRC = /usr/local/$(PLAT)-w64-mingw32/bin/
 INC_SRC = /usr/local/$(PLAT)-w64-mingw32/include/
 LIB_SRC = /usr/local/$(PLAT)-w64-mingw32/lib/
+
+
+# checking for msys2 with official snippet not possible in github-actions
+# check if file exists, and substitute with msys2-path if needed
+ifeq ("$(wildcard $($(PLAT)-w64-mingw32-windres))","")
+  WINRES = /opt/bin/$(PLAT)-w64-mingw32-windres
+endif
+
+ifeq ("$(wildcard $(/usr/local/$(PLAT)-w64-mingw32/bin/))","")
+  BIN_SRC = /mingw64/bin/
+endif
+
+ifeq ("$(wildcard $(/usr/local/$(PLAT)-w64-mingw32/include/))","")
+  INC_SRC = /mingw64/include/
+endif
+
+ifeq ("$(wildcard $(/usr/local/$(PLAT)-w64-mingw32/lib/))","")
+  LIB_SRC = /mingw64/lib/
+endif
+
 
 -include ../mingw.mk


### PR DESCRIPTION
- created GitHub-actions for Android, win64, linux64 
	- also creates nightly builds
-  added `msys2` section to Windows-64-bit Makefile
	- `msys2` supports getting dependencies through a package manager

## Issues/to-do

- linux-nightly not working on Debian stable, compilation only possible with `ubuntu-latest` libraries
	- working older version is in Debian official repositories, hasn't been updated, with custom changes
		- that same version is used for the flatpak version
- android APK has to be signed, possible through GitHub actions, not done yet
- Windows x86 version possible through GitHub actions, not done yet
- Android build failing if using Java 17
- at some point Windows build complained about `git` missing, not sure if still needed
